### PR TITLE
Fix grant per column on views

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/GrantRevokeParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/GrantRevokeParser.java
@@ -194,8 +194,7 @@ public class GrantRevokeParser {
                 }
                 final String objectName = ParserUtils.getObjectName(name);
                 final PgTable table = schema.getTable(objectName);
-                final PgView view = database.getSchema(schemaName).getView(
-                        objectName);
+                final PgView view = schema.getView(objectName);
 
                 if (table != null) {
                     for (String roleName : roles) {
@@ -243,6 +242,7 @@ public class GrantRevokeParser {
                 }
                 final String objectName = ParserUtils.getObjectName(name);
                 final PgTable table = schema.getTable(objectName);
+                final PgView view = schema.getView(objectName);
 
                 if (table != null) {
 
@@ -283,7 +283,47 @@ public class GrantRevokeParser {
                             }
                         }
                     }
-                } else {
+                } else if (view != null) {
+
+                    for (int i = 0; i < privileges.size(); i++) {
+                        String privKey = privileges.get(i);
+                        List<String> privValue = privilegesColumns.get(i);
+
+                        for (String columnName : privValue) {
+                            if (view.containsColumn(columnName)) {
+                                final PgColumn column = view
+                                        .getColumn(columnName);
+                                if (column == null) {
+                                    throw new RuntimeException(
+                                            MessageFormat.format(
+                                                    Resources
+                                                            .getString("CannotFindTableColumn"),
+                                                    columnName,
+                                                    view.getName(), parser
+                                                            .getString()));
+                                }
+                                for (String roleName : roles) {
+                                    PgColumnPrivilege columnPrivilege = column
+                                            .getPrivilege(roleName);
+                                    if (columnPrivilege == null) {
+                                        columnPrivilege = new PgColumnPrivilege(
+                                                roleName);
+                                        column.addPrivilege(columnPrivilege);
+                                    }
+                                    columnPrivilege.setPrivileges(privKey,
+                                            grant, grantOption);
+                                }
+                            } else {
+                                throw new ParserException(
+                                        MessageFormat.format(
+                                                Resources
+                                                        .getString("CannotFindColumnInTable"),
+                                                columnName, view.getName()));
+                            }
+                        }
+                    }
+                } 
+                else {
                     throw new RuntimeException(MessageFormat.format(
                             Resources.getString("CannotFindObject"), name,
                             statement));


### PR DESCRIPTION
If a schema has per column grant on a view, this error will be generated
```
Exception in thread "main" java.lang.RuntimeException: Cannot find object 'todos' for the statement 'GRANT SELECT(id) ON TABLE todos TO anonymous;'.
	at cz.startnet.utils.pgdiff.parsers.GrantRevokeParser.parse(GrantRevokeParser.java:287)
	at cz.startnet.utils.pgdiff.loader.PgDumpLoader.loadDatabaseSchema(PgDumpLoader.java:248)
	at cz.startnet.utils.pgdiff.loader.PgDumpLoader.loadDatabaseSchema(PgDumpLoader.java:287)
	at cz.startnet.utils.pgdiff.PgDiff.createDiff(PgDiff.java:30)
	at cz.startnet.utils.pgdiff.Main.main(Main.java:39)
```