### PR TITLE
Fix bug in create trigger

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTriggerParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTriggerParser.java
@@ -103,8 +103,11 @@ public class CreateTriggerParser {
             trigger.setWhen(parser.getExpression());
             parser.expect(")");
         }
-
-        parser.expect("EXECUTE", "PROCEDURE");
+    
+        parser.expect("EXECUTE");
+        parser.expectOptional("PROCEDURE");
+        parser.expectOptional("FUNCTION");
+        
         trigger.setFunction(parser.getRest());
 
         final boolean ignoreSlonyTrigger = ignoreSlonyTriggers


### PR DESCRIPTION
Error occurs if the trigger is a function
eg.
`CREATE TRIGGER abc AFTER INSERT ON data.users FOR EACH ROW EXECUTE FUNCTION data.user_trigger_function();`


https://www.postgresql.org/docs/current/sql-createtrigger.html